### PR TITLE
Added missing / to meta-data url

### DIFF
--- a/packer/init.aws.region
+++ b/packer/init.aws.region
@@ -16,7 +16,7 @@ function get_aws_metadata_value() {
 
 
 function set_aws_defaults_from_environ() {
-  local zone=$(get_aws_metadata_value "/placement/availability-zone")
+  local zone=$(get_aws_metadata_value "/placement/availability-zone/")
   local region=${zone%?}
   local mac_addr=$(get_aws_metadata_value "/network/interfaces/macs/")
   local vpc_id=$(get_aws_metadata_value "/network/interfaces/macs/${mac_addr}vpc-id")


### PR DESCRIPTION
fix(aws/init): Adding missing '/' in meta-data AZ url

availibility zone meta-data endpoint will always return an empty response if the trailing / is missing.
This might have broken starting spinnaker in a private subnet as it will default to trying to reach us-east-1, which is not allowed without a NAT. (not confirmed this fixes that issue)


